### PR TITLE
Dev/feat/photo

### DIFF
--- a/src/main/java/com/prgrms2/java/bitta/feed/entity/Feed.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/entity/Feed.java
@@ -1,5 +1,6 @@
 package com.prgrms2.java.bitta.feed.entity;
 
+import com.prgrms2.java.bitta.photo.entity.Photo;
 import com.prgrms2.java.bitta.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -7,6 +8,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @Builder
@@ -31,4 +33,8 @@ public class Feed {
     @CreatedDate
     @Column(updatable = false, nullable = false)
     private LocalDateTime createdAt;
+
+    //사진들의 링크 집합입니다. 유저보다는 일단 feed 자체에 연결시키겠습니다
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Photo> photos;
 }

--- a/src/main/java/com/prgrms2/java/bitta/feed/service/FeedService.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/service/FeedService.java
@@ -11,7 +11,7 @@ public interface FeedService {
 
     List<FeedDTO> readAll();
 
-    String insert(FeedDTO feedDto);
+    Feed insert(FeedDTO feedDto);
 
     Optional<FeedDTO> update(FeedDTO feedDto);
 

--- a/src/main/java/com/prgrms2/java/bitta/feed/service/FeedServiceImpl.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/service/FeedServiceImpl.java
@@ -36,10 +36,10 @@ public class FeedServiceImpl implements FeedService {
 
     @Override
     @Transactional
-    public String insert(FeedDTO feedDTO) {
+    public Feed insert(FeedDTO feedDTO) {
         Feed feed = dtoToEntity(feedDTO);
-        feedRepository.save(feed);
-        return "Feed created successfully";
+        return feedRepository.save(feed);
+
     }
 
     @Override

--- a/src/main/java/com/prgrms2/java/bitta/photo/entity/Photo.java
+++ b/src/main/java/com/prgrms2/java/bitta/photo/entity/Photo.java
@@ -27,8 +27,8 @@ public class Photo {
 
     //이곳에 있던 user 필드 삭제. feed 가 이미 user 에게 연결되어 있고, 사진은 feed 로만 연결되어도 문제 없을거 같아요
 
-    @ManyToOne
-    @JoinColumn(name = "feed_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feed_id", nullable = false)
     private Feed feed;
 
     @CreatedDate

--- a/src/main/java/com/prgrms2/java/bitta/photo/entity/Photo.java
+++ b/src/main/java/com/prgrms2/java/bitta/photo/entity/Photo.java
@@ -25,9 +25,7 @@ public class Photo {
 
     private String photoUrl;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
+    //이곳에 있던 user 필드 삭제. feed 가 이미 user 에게 연결되어 있고, 사진은 feed 로만 연결되어도 문제 없을거 같아요
 
     @ManyToOne
     @JoinColumn(name = "feed_id")

--- a/src/main/java/com/prgrms2/java/bitta/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/prgrms2/java/bitta/photo/repository/PhotoRepository.java
@@ -1,9 +1,13 @@
 package com.prgrms2.java.bitta.photo.repository;
 
+import com.prgrms2.java.bitta.feed.entity.Feed;
 import com.prgrms2.java.bitta.photo.entity.Photo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
+    List<Photo> findByFeed(Feed feed);
 }

--- a/src/main/java/com/prgrms2/java/bitta/photo/service/PhotoService.java
+++ b/src/main/java/com/prgrms2/java/bitta/photo/service/PhotoService.java
@@ -21,7 +21,7 @@ public class PhotoService {
     }
 
     public String uploadFile(MultipartFile file) throws IOException {
-        String filePath = "uploads/" + file.getOriginalFilename();
+        String filePath = " " + file.getOriginalFilename(); //file path. 자료 저장을 어디다 하냐에 바꾸면 됩니다.
         File dest = new File(filePath);
         file.transferTo(dest);
 

--- a/src/main/java/com/prgrms2/java/bitta/photo/service/PhotoService.java
+++ b/src/main/java/com/prgrms2/java/bitta/photo/service/PhotoService.java
@@ -1,0 +1,55 @@
+package com.prgrms2.java.bitta.photo.service;
+
+import com.prgrms2.java.bitta.feed.entity.Feed;
+import com.prgrms2.java.bitta.photo.entity.Photo;
+import com.prgrms2.java.bitta.photo.repository.PhotoRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class PhotoService {
+
+    private final PhotoRepository photoRepository;
+
+    public PhotoService(PhotoRepository photoRepository) {
+        this.photoRepository = photoRepository;
+    }
+
+    public String uploadFile(MultipartFile file) throws IOException {
+        String filePath = "uploads/" + file.getOriginalFilename();
+        File dest = new File(filePath);
+        file.transferTo(dest);
+
+        return filePath;
+    }
+
+    public List<Photo> uploadPhotos(List<MultipartFile> files, Feed feed) throws IOException {
+
+        deletePhotosByFeed(feed);
+
+        return files.stream().map(file -> {
+            try {
+                String fileUrl = uploadFile(file);
+                Photo photo = Photo.builder()
+                        .photoUrl(fileUrl)
+                        .fileSize(file.getSize())
+                        .feed(feed)
+                        .build();
+                return photoRepository.save(photo);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to upload photo", e);
+            }
+        }).collect(Collectors.toList());
+    }
+
+
+    public void deletePhotosByFeed(Feed feed) {
+        List<Photo> photos = photoRepository.findByFeed(feed);
+        photoRepository.deleteAll(photos);
+    }
+}

--- a/src/main/java/com/prgrms2/java/bitta/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/prgrms2/java/bitta/photo/service/PhotoServiceImpl.java
@@ -1,8 +1,0 @@
-package com.prgrms2.java.bitta.photo.service;
-
-import com.prgrms2.java.bitta.jobpost.service.PhotoService;
-import org.springframework.stereotype.Service;
-
-@Service
-public class PhotoServiceImpl implements PhotoService {
-}


### PR DESCRIPTION
## closed #26
<!---- 자신이 완료한 이슈를 닫아주세요 -->
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
photo 의  entity, repository, service 작성

PhotoSerivceImpl 이 왠지 jobpost 쪽 PhotoService 랑 연결되어 있어서 그냥 새로 클래스를 만들어 버렸습니다.
혹시 jobpost PhotoService 인터페이스에 연결되어 있던 이유가 있다면 수정하겠습니다.

## #️⃣연관된 이슈
<!---- Resolves: #(Isuue Number) -->


## ☑️ PR 유형
- [x] 새로운 기능 추가



## 📝 작업 내용
URL 기반으로 사진을 불러와 4개를 feed 에 띄우는 코드를 작성했습니다.

[ ] 좀 설명이 필요한데 PhotoService 클래스 내부에 uploadFile method 보시면 String filePath=" " 가 있을겁니다. 여기가 사진이 upload 될 시 저장되는 공간인데, 일단 비워뒀습니다. 실제 상업용 deploy 시 사진 같은 경우 용량이 상당히 크기 때문에 AWS S3 등 클라우드 스토리지를 사용하는것이 편할 것으로 보입니다.
![image](https://github.com/user-attachments/assets/59f637c6-1ac9-4c9a-958f-5a005ba66cf6)


[ ] Photo entity에서 User 필드를 삭제했습니다. 사진에 유저를 연결 시킬 이유가 없었고, 사진은 이제 feed 와 묶여있습니다. 어차피 user 의 변경은 feed 에도 영향을 끼치니 photo 가 따로 user 와 연결 될 필요는 없을 것입니다.


[ ] feed 내부에서 변경점이 좀 많습니다. 일단 개별적으로 feedDto = null 체크를 지웠는데, @RequestBody 어노테이션이 해당 체크를 해주기에 이중이라 지웠습니다. 제가 이해하지 못한 이유가 있었다면 알려주시면 다시 만들어 두겠습니다.  에러코드는 저희가 따로 Universal error 를 지정하지 않았기에 그냥 임의로 적어 뒀습니다. 나중에 변경해도 될 것 같습니다. 이 외에도 자잘한 변경점이 몇개 있는데 전체 코드에 큰 영향을 끼치진 않을 것으로 보입니다. 혹시 문제 생기면 말씀해 주세요.


[ ] 현재 feed 생성시 사진 4장을 요구하고, 만약 주지 않을경우 그냥 넘어갑니다. 이후에 따로 수정을 할 수 있게 해뒀는데, 현재로선 4개의 사진을 한번에 올리거나, 전부 삭제하거나 형식으로 구현 해 뒀습니다. 개별적으로 올리거나 개별적으로 삭제하는게 불가능 한 방식인데 이는 나중에 제가 다시 해보겠습니다. 지금 좀 머리가 터질거 같아서


## ✅ 피드백 반영사항


## 💬 리뷰 요구사항
저도 지금 다시 한번 읽으면서 리뷰하는 중이니 리뷰 끝나더라도 미리 Merge 하지 말아주세요!! 충돌 이슈등을 확인하기 위해 pull request 먼저 올리는 거에요!
