### PR TITLE
pullrequest: 피드 예외 처리 및 기능 수정

### DIFF
--- a/src/main/java/com/prgrms2/java/bitta/feed/controller/FeedController.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/controller/FeedController.java
@@ -2,64 +2,56 @@ package com.prgrms2.java.bitta.feed.controller;
 
 import com.prgrms2.java.bitta.feed.dto.FeedDTO;
 import com.prgrms2.java.bitta.feed.service.FeedService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/feed")
 @RequiredArgsConstructor
+@Validated
 public class FeedController {
     private final FeedService feedService;
 
     @GetMapping
     public ResponseEntity<?> getFeed() {
-        List<FeedDTO> feedDTOList = feedService.readAll();
-
-        if (feedDTOList.isEmpty()) {
-            return ResponseEntity.notFound().build();
-        }
-
-        return ResponseEntity.ok(feedDTOList);
+        return ResponseEntity.ok(
+                Map.of("message", "피드를 성공적으로 조회했습니다.", "result", feedService.readAll())
+        );
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<?> getFeedById(@PathVariable("id") Long feedId) {
-        Optional<FeedDTO> feedDto = feedService.read(feedId);
-
-        if (feedDto.isEmpty()) {
-            return ResponseEntity.notFound().build();
-        }
-
-        return ResponseEntity.ok(feedDto.get());
+    public ResponseEntity<?> getFeedById(@PathVariable("id") @Min(1) Long id) {
+        return ResponseEntity.ok(
+                Map.of("message", "피드를 성공적으로 조회했습니다.", "result", feedService.read(id))
+        );
     }
 
     @PostMapping
-    public ResponseEntity<?> createFeed(@RequestBody FeedDTO feedDto) {
-        if (feedDto == null) {
-            return ResponseEntity.badRequest().build();
-        }
+    public ResponseEntity<?> createFeed(@RequestBody @Valid FeedDTO feedDto) {
+        feedService.insert(feedDto);
 
-        return ResponseEntity.ok(feedService.insert(feedDto));
+        return ResponseEntity.ok().body(Map.of("message", "피드가 등록되었습니다."));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<?> modifyFeed(@PathVariable("id") Long feedId, @RequestBody FeedDTO feedDto) {
-        if (feedDto == null) {
-            return ResponseEntity.badRequest().build();
-        }
+    public ResponseEntity<?> modifyFeed(@PathVariable("id") @Min(1) Long id, @RequestBody @Valid FeedDTO feedDTO) {
+        feedDTO.setId(id);
 
-        feedDto.setFeedId(feedId);
+        feedService.update(feedDTO);
 
-        return ResponseEntity.ok(feedService.update(feedDto));
+        return ResponseEntity.ok().body(Map.of("message", "피드가 수정되었습니다."));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<?> deleteFeed(@PathVariable("id") Long feedId) {
-        return feedService.delete(feedId) ?
-                ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    public ResponseEntity<?> deleteFeed(@PathVariable("id") @Min(1) Long id) {
+        feedService.delete(id);
+
+        return ResponseEntity.ok().body(Map.of("message", "피드가 삭제되었습니다."));
     }
 }

--- a/src/main/java/com/prgrms2/java/bitta/feed/controller/advice/FeedControllerAdvice.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/controller/advice/FeedControllerAdvice.java
@@ -1,0 +1,33 @@
+package com.prgrms2.java.bitta.feed.controller.advice;
+
+import com.prgrms2.java.bitta.feed.exception.FeedException;
+import com.prgrms2.java.bitta.feed.exception.FeedTaskException;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class FeedControllerAdvice {
+    @ExceptionHandler(FeedTaskException.class)
+    public ResponseEntity<?> handleArgsException(FeedTaskException e) {
+        return ResponseEntity.status(e.getCode())
+                .body(Map.of("error", e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> handleArgsException(MethodArgumentNotValidException e) {
+        return ResponseEntity.status(e.getStatusCode())
+                .body(Map.of("error", "잘못된 요청입니다.", "reason", e.getMessage()));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<?> handleArgsException(ConstraintViolationException e) {
+        return ResponseEntity.badRequest()
+                .body(Map.of("error", "잘못된 요청입니다.", "reason", "ID는 음수가 될 수 없습니다."));
+    }
+}

--- a/src/main/java/com/prgrms2/java/bitta/feed/dto/FeedDTO.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/dto/FeedDTO.java
@@ -1,7 +1,6 @@
 package com.prgrms2.java.bitta.feed.dto;
 
-import com.prgrms2.java.bitta.feed.entity.Feed;
-import com.prgrms2.java.bitta.member.entity.Member;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,27 +13,21 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 public class FeedDTO {
-    private Long feedId;
+    @Min(value = 1, message = "ID는 음수가 될 수 없습니다.")
+    private Long id;
+
+    @NotBlank(message = "제목은 비워둘 수 없습니다.")
+    @Size(min = 1, max = 50, message = "제목은 1 ~ 50자 이하여야 합니다.")
     private String title;
-    private String content;
-    private Long memberId;
+
+    @NotNull
+    @Builder.Default
+    private String content = "";
+
+    @NotBlank(message = "이메일은 비워둘 수 없습니다.")
+    @Email(message = "올바른 이메일 형식이어야 합니다.")
+    private String email;
+
+    @PastOrPresent(message = "생성일자는 현재 시점 혹은 이전이어야 합니다.")
     private LocalDateTime createdAt;
-
-    public FeedDTO(Feed feed) {
-        this.feedId = feed.getFeedId();
-        this.title = feed.getTitle();
-        this.content = feed.getContent();
-        this.memberId = feed.getMember().getMemberId();
-        this.createdAt = feed.getCreatedAt();
-    }
-
-    public Feed toEntity(Member member) {
-        Feed feed = Feed.builder()
-                .title(title)         // title을 넘겨줌
-                .content(content)     // content를 넘겨줌
-                .member(member)       // Member 객체를 넘겨줌
-                .createdAt(createdAt) // createdAt을 넘겨줌
-                .build();
-        return feed;
-    }
 }

--- a/src/main/java/com/prgrms2/java/bitta/feed/entity/Feed.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/entity/Feed.java
@@ -17,14 +17,18 @@ import java.time.LocalDateTime;
 public class Feed {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long feedId;
+    @Setter(AccessLevel.NONE)
+    private Long id;
 
+    @Column(nullable = false, length = 50)
     private String title;
 
+    @Lob
+    @Column(nullable = false)
     private String content;
 
     @ManyToOne
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @CreatedDate

--- a/src/main/java/com/prgrms2/java/bitta/feed/exception/FeedException.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/exception/FeedException.java
@@ -1,0 +1,22 @@
+package com.prgrms2.java.bitta.feed.exception;
+
+
+public enum FeedException {
+    NOT_FOUND(404, "피드가 존재하지 않습니다."),
+    BAD_REQUEST(400, "잘못된 요청입니다."),
+    BAD_AUTHORITY(403, "권한이 없습니다."),
+    CANNOT_INSERT(400, "피드를 등록할 수 없습니다."),
+    CANNOT_FOUND(404, "피드가 존재하지 않습니다."),
+    CANNOT_MODIFY(400, "피드를 수정할 수 없습니다."),
+    CANNOT_DELETE(404, "삭제할 피드가 존재하지 않습니다");
+
+    private FeedTaskException feedTaskException;
+
+    FeedException(int code, String message) {
+        feedTaskException = new FeedTaskException(code, message);
+    }
+
+    public FeedTaskException get() {
+        return feedTaskException;
+    }
+}

--- a/src/main/java/com/prgrms2/java/bitta/feed/exception/FeedTaskException.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/exception/FeedTaskException.java
@@ -1,0 +1,11 @@
+package com.prgrms2.java.bitta.feed.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class FeedTaskException extends RuntimeException {
+    private int code;
+    private String message;
+}

--- a/src/main/java/com/prgrms2/java/bitta/feed/repository/FeedRepository.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/repository/FeedRepository.java
@@ -10,6 +10,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface FeedRepository extends JpaRepository<Feed, Long> {
     @Modifying
-    @Query("DELETE FROM Feed f WHERE f.feedId = :feedId")
-    Long deleteByFeedIdAndReturnCount(@Param("feedId") Long feedId);
+    @Query("DELETE FROM Feed f WHERE f.id = :id")
+    Long deleteByIdAndReturnCount(@Param("id") Long id);
 }

--- a/src/main/java/com/prgrms2/java/bitta/feed/service/FeedService.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/service/FeedService.java
@@ -1,39 +1,17 @@
 package com.prgrms2.java.bitta.feed.service;
 
 import com.prgrms2.java.bitta.feed.dto.FeedDTO;
-import com.prgrms2.java.bitta.feed.entity.Feed;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface FeedService {
-    Optional<FeedDTO> read(Long id);
+    FeedDTO read(Long id);
 
     List<FeedDTO> readAll();
 
-    String insert(FeedDTO feedDto);
+    void insert(FeedDTO feedDto);
 
-    Optional<FeedDTO> update(FeedDTO feedDto);
+    void update(FeedDTO feedDto);
 
-    boolean delete(Long id);
-
-    default Feed dtoToEntity(FeedDTO feedDto) {
-        // 회원 아이디는 UserService 에서 할당해야 합니다.
-        return Feed.builder()
-                .feedId(feedDto.getFeedId())
-                .title(feedDto.getTitle())
-                .content(feedDto.getContent())
-                .createdAt(feedDto.getCreatedAt())
-                .build();
-    }
-
-    default FeedDTO entityToDto(Feed feed) {
-        return FeedDTO.builder()
-                .feedId(feed.getFeedId())
-                .title(feed.getTitle())
-                .content(feed.getContent())
-                .createdAt(feed.getCreatedAt())
-                .memberId(feed.getMember().getMemberId())
-                .build();
-    }
+    void delete(Long id);
 }

--- a/src/main/java/com/prgrms2/java/bitta/member/service/MemberService.java
+++ b/src/main/java/com/prgrms2/java/bitta/member/service/MemberService.java
@@ -39,6 +39,10 @@ public class MemberService {                              /**로그인 로직*/
         return new MemberDTO(member);
     }
 
+    public Member getByEmail(String email) {
+        return memberRepository.findByEmail(email).orElseThrow(MemberException.NOT_FOUND::get);
+    }
+
     public MemberDTO register(MemberDTO memberDTO) {      /**가입*/
         try{
             Member member = memberDTO.toEntity();


### PR DESCRIPTION
## closed #38
피드 컴포넌트의 예외를 처리하고 필드 검증 설정과 약간의 리팩토링을 수행했습니다.

## #️⃣연관된 이슈
See also: #21 
병합 후에 테스트 코드를 수정해야 합니다.


## ☑️ PR 유형
- [x] 새로운 기능 추가
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링


## 📝 작업 내용
#### 피드 엔티티 필드 수정
- 피드 PK명을 id로 바꾸고 Setter 접근을 불가능하도록 설정합니다.
- 제목의 길이를 50자로 제한하고, 내용은 LOB 타입으로 변경합니다.
- 컬럼 전체에 nullable을 false로 설정합니다.

Commit : d6e9d539602887e51ae93a3f25c0778b4b09705f

#### 피드 예외 처리
- Feed 관련 예외 클래스와 예외 인스턴스를 제공하는 Enum 클래스를 추가합니다.
- Feed 관련 예외를 처리하고 메시지를 전달하는  ControllerAdvice 클래스를 추가합니다.

Commit : 37b54057b2c9197506d24123915b65e687721b0e

#### DTO 유효 검증 설정
- 불필요한 생성자와 엔티티 변환 메소드를 제거합니다.
- 필드 별 검증 규칙과 에러 메시지를 설정합니다.

Commit: af31100ea6f0f3a42b1352a119b44a73e25fba2c

#### 피드 서비스 수정
- 조회 기능을 제외한 메소드 반환 형을 void로 통일합니다.
- 검색 결과 유효 여부를 컨트롤러가 아닌 서비스가 관리합니다.
- 특정 조건에서 예외를 Throw 하도록 설정합니다.
- DTO <-> 엔티티 변환 메소드를 구현 클래스에 위임합니다.
- 회원 서비스를 주입 및 메소드를 통해 Member 객체를 얻습니다.

Commit: cf2ba5753c2c88029c2dbfff349bbaad084b404f

#### 피드 컨트롤러 수정
- 경로 변수와 요청 바디의 값 유효성 검증 기능을 추가합니다.
- 응답 메시지의 형식을 통일합니다.

Commit: 06580ef73a4717e58e3aca6955e55a9a64d15796

#### 피드 레포지토리 수정
- Feed의 변경된 PK 필드명을 메소드에 적용합니다.

Commit: 506a19e3637a073cd7008019d1dc3150f96821fc

## ✅ 피드백 반영사항
팀원 분들과 회의에서 나온 결과를 적용하고, 예외를 처리하고 리팩토링 하는데 중점을 두어 작업했습니다.

## 💬 리뷰 요구사항
피드백 부탁드립니다.