### PR TITLE
Origin/dev/feat/photo video

### DIFF
--- a/src/main/java/com/prgrms2/java/bitta/feed/controller/FeedController.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/controller/FeedController.java
@@ -2,13 +2,19 @@ package com.prgrms2.java.bitta.feed.controller;
 
 import com.prgrms2.java.bitta.feed.dto.FeedDTO;
 import com.prgrms2.java.bitta.feed.service.FeedService;
+import com.prgrms2.java.bitta.member.service.MemberService;
+import com.prgrms2.java.bitta.photo.service.PhotoService;
+import com.prgrms2.java.bitta.video.service.VideoService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -17,6 +23,11 @@ import java.util.Map;
 @Validated
 public class FeedController {
     private final FeedService feedService;
+    private final PhotoService photoService;
+    private final VideoService videoService;
+    private final MemberService memberService;
+
+
 
     @GetMapping
     public ResponseEntity<?> getFeed() {
@@ -54,4 +65,28 @@ public class FeedController {
 
         return ResponseEntity.ok().body(Map.of("message", "피드가 삭제되었습니다."));
     }
+
+
+    @PostMapping("/{id}/photos")
+    public ResponseEntity<?> addPhotosToFeed(@PathVariable("id") Long feedId, @RequestParam("photos") List<MultipartFile> photos) {
+        try {
+            feedService.addPhotosToFeed(feedId, photos);
+            return ResponseEntity.ok().body(Map.of("message", "사진이 업로드되었습니다."));
+        } catch (IOException e) {
+            return ResponseEntity.status(500).body("사진 업로드 실패");
+        }
+
+    }
+
+    @PostMapping("/{id}/videos")
+    public ResponseEntity<?> addVideosToFeed(@PathVariable("id") Long feedId, @RequestParam("videos") List<MultipartFile> videos) {
+        try {
+            feedService.addVideosToFeed(feedId, videos);
+            return ResponseEntity.ok().body(Map.of("message", "비디오가 업로드되었습니다."));
+        } catch (IOException e) {
+            return ResponseEntity.status(500).body("비디오 업로드 실패");
+        }
+
+    }
 }
+

--- a/src/main/java/com/prgrms2/java/bitta/feed/dto/FeedDTO.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/dto/FeedDTO.java
@@ -48,7 +48,7 @@ public class FeedDTO {
         this.email = feed.getMember().getEmail();
         this.createdAt = feed.getCreatedAt();
 
-        
+
         this.photoUrls = feed.getPhotos().stream()
                 .map(Photo::getPhotoUrl)
                 .toList();

--- a/src/main/java/com/prgrms2/java/bitta/feed/dto/FeedDTO.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/dto/FeedDTO.java
@@ -1,5 +1,6 @@
 package com.prgrms2.java.bitta.feed.dto;
 
+import com.prgrms2.java.bitta.feed.entity.Feed;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,6 +8,10 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
+
+import com.prgrms2.java.bitta.photo.entity.Photo;
+import com.prgrms2.java.bitta.video.entity.Video;
 
 @Data
 @Builder
@@ -30,4 +35,26 @@ public class FeedDTO {
 
     @PastOrPresent(message = "생성일자는 현재 시점 혹은 이전이어야 합니다.")
     private LocalDateTime createdAt;
+
+
+    //photo 와 video DTO
+    private List<String> photoUrls;
+    private List<String> videoUrls;
+
+    public FeedDTO(Feed feed) {
+        this.id = feed.getId();
+        this.title = feed.getTitle();
+        this.content = feed.getContent();
+        this.email = feed.getMember().getEmail();
+        this.createdAt = feed.getCreatedAt();
+
+        
+        this.photoUrls = feed.getPhotos().stream()
+                .map(Photo::getPhotoUrl)
+                .toList();
+        this.videoUrls = feed.getVideos().stream()
+                .map(Video::getVideoUrl)
+                .toList();
+    }
+
 }

--- a/src/main/java/com/prgrms2/java/bitta/feed/entity/Feed.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/entity/Feed.java
@@ -1,12 +1,16 @@
 package com.prgrms2.java.bitta.feed.entity;
 
 import com.prgrms2.java.bitta.member.entity.Member;
+import com.prgrms2.java.bitta.photo.entity.Photo;
+import com.prgrms2.java.bitta.video.entity.Video;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @Builder
@@ -34,4 +38,23 @@ public class Feed {
     @CreatedDate
     @Column(updatable = false, nullable = false)
     private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Photo> photos = new ArrayList<>();
+
+    // 비디오 리스트
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Video> videos = new ArrayList<>();
+
+    // 사진 추가 메서드
+    public void addPhoto(Photo photo) {
+        this.photos.add(photo);
+        photo.setFeed(this);
+    }
+
+    // 비디오 추가 메서드
+    public void addVideo(Video video) {
+        this.videos.add(video);
+        video.setFeed(this);
+    }
 }

--- a/src/main/java/com/prgrms2/java/bitta/feed/service/FeedService.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/service/FeedService.java
@@ -1,7 +1,9 @@
 package com.prgrms2.java.bitta.feed.service;
 
 import com.prgrms2.java.bitta.feed.dto.FeedDTO;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 public interface FeedService {
@@ -14,4 +16,8 @@ public interface FeedService {
     void update(FeedDTO feedDto);
 
     void delete(Long id);
+
+    //photo, video
+    void addPhotosToFeed(Long feedId, List<MultipartFile> photos) throws IOException;
+    void addVideosToFeed(Long feedId, List<MultipartFile> videos) throws IOException;
 }

--- a/src/main/java/com/prgrms2/java/bitta/feed/service/FeedServiceImpl.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/service/FeedServiceImpl.java
@@ -5,16 +5,23 @@ import com.prgrms2.java.bitta.feed.entity.Feed;
 import com.prgrms2.java.bitta.feed.exception.FeedException;
 import com.prgrms2.java.bitta.feed.repository.FeedRepository;
 import com.prgrms2.java.bitta.member.service.MemberService;
+import com.prgrms2.java.bitta.photo.service.PhotoService;
+import com.prgrms2.java.bitta.video.service.VideoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class FeedServiceImpl implements FeedService {
     private final FeedRepository feedRepository;
+
+    private final PhotoService photoService;
+    private final VideoService videoService;
 
     private final MemberService memberService;
 
@@ -70,6 +77,24 @@ public class FeedServiceImpl implements FeedService {
             throw FeedException.CANNOT_DELETE.get();
         }
     }
+
+    //photo and video
+    @Override
+    @Transactional
+    public void addPhotosToFeed(Long feedId, List<MultipartFile> photos) throws IOException {
+        Feed feed = feedRepository.findById(feedId)
+                .orElseThrow(FeedException.CANNOT_FOUND::get);
+        photoService.uploadPhotos(photos, feed);
+    }
+
+    @Override
+    @Transactional
+    public void addVideosToFeed(Long feedId, List<MultipartFile> videos) throws IOException {
+        Feed feed = feedRepository.findById(feedId)
+                .orElseThrow(FeedException.CANNOT_FOUND::get);
+        videoService.uploadVideos(videos, feed);
+    }
+
 
     private Feed dtoToEntity(FeedDTO feedDto) {
         return Feed.builder()

--- a/src/main/java/com/prgrms2/java/bitta/photo/entity/Photo.java
+++ b/src/main/java/com/prgrms2/java/bitta/photo/entity/Photo.java
@@ -25,11 +25,7 @@ public class Photo {
 
     private String photoUrl;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private Member member;
-
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feed_id")
     private Feed feed;
 

--- a/src/main/java/com/prgrms2/java/bitta/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/prgrms2/java/bitta/photo/repository/PhotoRepository.java
@@ -1,9 +1,13 @@
 package com.prgrms2.java.bitta.photo.repository;
 
+import com.prgrms2.java.bitta.feed.entity.Feed;
 import com.prgrms2.java.bitta.photo.entity.Photo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
+    List<Photo> findByFeed(Feed feed);
 }

--- a/src/main/java/com/prgrms2/java/bitta/photo/service/PhotoService.java
+++ b/src/main/java/com/prgrms2/java/bitta/photo/service/PhotoService.java
@@ -1,0 +1,13 @@
+package com.prgrms2.java.bitta.photo.service;
+
+import com.prgrms2.java.bitta.feed.entity.Feed;
+import com.prgrms2.java.bitta.photo.entity.Photo;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface PhotoService {
+    List<Photo> uploadPhotos(List<MultipartFile> files, Feed feed) throws IOException;
+    void deletePhotosByFeed(Feed feed);
+}

--- a/src/main/java/com/prgrms2/java/bitta/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/prgrms2/java/bitta/photo/service/PhotoServiceImpl.java
@@ -1,7 +1,46 @@
 package com.prgrms2.java.bitta.photo.service;
 
+import com.prgrms2.java.bitta.feed.entity.Feed;
+import com.prgrms2.java.bitta.photo.entity.Photo;
+import com.prgrms2.java.bitta.photo.repository.PhotoRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
 
 @Service
-public class PhotoServiceImpl {
+@RequiredArgsConstructor
+public class PhotoServiceImpl implements PhotoService{
+    private final PhotoRepository photoRepository;
+
+    @Transactional
+    public List<Photo> uploadPhotos(List<MultipartFile> files, Feed feed) throws IOException {
+        for (MultipartFile file : files) {
+            String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+            String filePath = "uploads/photos/" + fileName;
+
+            File dest = new File(filePath);
+            file.transferTo(dest);
+
+            Photo photo = Photo.builder()
+                    .photoUrl(filePath)
+                    .fileSize(file.getSize())
+                    .feed(feed)
+                    .build();
+
+            photoRepository.save(photo);
+        }
+        return photoRepository.findByFeed(feed);
+    }
+
+    @Transactional
+    public void deletePhotosByFeed(Feed feed) {
+        List<Photo> photos = photoRepository.findByFeed(feed);
+        photoRepository.deleteAll(photos);
+    }
 }

--- a/src/main/java/com/prgrms2/java/bitta/video/entity/Video.java
+++ b/src/main/java/com/prgrms2/java/bitta/video/entity/Video.java
@@ -27,11 +27,7 @@ public class Video {
 
     private String videoUrl;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private Member member;
-
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feed_id")
     private Feed feed;
 

--- a/src/main/java/com/prgrms2/java/bitta/video/repository/VideoRepository.java
+++ b/src/main/java/com/prgrms2/java/bitta/video/repository/VideoRepository.java
@@ -1,9 +1,13 @@
 package com.prgrms2.java.bitta.video.repository;
 
+import com.prgrms2.java.bitta.feed.entity.Feed;
 import com.prgrms2.java.bitta.video.entity.Video;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface VideoRepository extends JpaRepository<Video, Long> {
+    List<Video> findByFeed(Feed feed);
 }

--- a/src/main/java/com/prgrms2/java/bitta/video/service/VideoService.java
+++ b/src/main/java/com/prgrms2/java/bitta/video/service/VideoService.java
@@ -1,4 +1,14 @@
 package com.prgrms2.java.bitta.video.service;
 
+import com.prgrms2.java.bitta.feed.entity.Feed;
+import com.prgrms2.java.bitta.video.entity.Video;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
 public interface VideoService {
+    List<Video> uploadVideos(List<MultipartFile> files, Feed feed) throws IOException;
+    void deleteVideosByFeed(Feed feed);
 }
+

--- a/src/main/java/com/prgrms2/java/bitta/video/service/VideoServiceImpl.java
+++ b/src/main/java/com/prgrms2/java/bitta/video/service/VideoServiceImpl.java
@@ -1,7 +1,46 @@
 package com.prgrms2.java.bitta.video.service;
 
+import com.prgrms2.java.bitta.feed.entity.Feed;
+import com.prgrms2.java.bitta.video.entity.Video;
+import com.prgrms2.java.bitta.video.repository.VideoRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
 
 @Service
+@RequiredArgsConstructor
 public class VideoServiceImpl implements VideoService {
+    private final VideoRepository videoRepository;
+
+    @Transactional
+    public List<Video> uploadVideos(List<MultipartFile> files, Feed feed) throws IOException {
+        for (MultipartFile file : files) {
+            String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+            String filePath = "uploads/videos/" + fileName;
+
+            File dest = new File(filePath);
+            file.transferTo(dest);
+
+            Video video = Video.builder()
+                    .videoUrl(filePath)
+                    .fileSize(file.getSize())
+                    .feed(feed)
+                    .build();
+
+            videoRepository.save(video);
+        }
+        return videoRepository.findByFeed(feed);
+    }
+
+    @Transactional
+    public void deleteVideosByFeed(Feed feed) {
+        List<Video> videos = videoRepository.findByFeed(feed);
+        videoRepository.deleteAll(videos);
+    }
 }


### PR DESCRIPTION
## closed #26 

- 사진 및 비디오를 Feed 에 추가하는 기능을 개발 했습니다
- 현재 feed 를 처음 만드는 시점에서 사진 밑 비디오 추가를 하는 것보단 개별적으로 추가 할 수 있게 해 뒀습니다.
- 사진 밑 비디오를 저장하는 공간은 /upload/photo 와 /upload/video 로 임시적으로 적어 뒀지만 나중에 deploy 시점에서 폴더 만들어서 지정해 주면 될 것 같습니다.
- 현재 올리고 지우는게 한번에 진행됩니다. 즉 하나씩 지우기가 불가능 합니다. 이는 나중에 고칠 예정입니다.
- 현재 비디오를 올릴때 제한이 없습니다. 이 또한 차후 고칠 예정입니다
- 

## #️⃣연관된 이슈
Resolves: #26 


## ☑️ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더명 수정
- [ ] CSS 등 사용자 UI 디자인 변경


## 📝 작업 내용
- Feed 생성 후, 별도로 사진과 비디오를 추가할 수 있는 API를 구현했습니다.
- 사진 및 비디오는 각각의 업로드 경로에 저장되며, DB에는 파일 경로 및 메타데이터가 저장됩니다.
- 사진 추가 API: `/api/v1/feed/{id}/photos`
- 비디오 추가 API: `/api/v1/feed/{id}/videos`
- 해당 기능은 새로운 엔드포인트를 통해 별도로 실행할 수 있으며, Feed에 여러 개의 파일을 한번에 추가할 수 있습니다.


## ✅ 피드백 반영사항


## 💬 리뷰 요구사항
feed 추가 내용들이 있습니다. 전부 //photo 와 video 로 추가된 내용들을 더해뒀습니다.
