### PR TITLE
pullrequest 피드 컨트롤러 테스트 오류 수정

### DIFF
--- a/src/main/java/com/prgrms2/java/bitta/feed/dto/FeedDTO.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/dto/FeedDTO.java
@@ -32,7 +32,7 @@ public class FeedDTO {
 
     @Schema(title = "회원 ID (FK)", description = "회원의 고유 ID 입니다.", example = "1", minimum = "1")
     @Min(value = 1, message = "ID는 음수가 될 수 없습니다.")
-    @NotBlank(message = "회원 ID는 누락될 수 없습니다.")
+    @NotNull(message = "회원 ID는 누락될 수 없습니다.")
     private Long memberId;
 
     @Schema(title = "피드 생성일시", description = "피드가 생성된 날짜 및 시간입니다.", example = "2023-09-24T14:45:00")

--- a/src/main/java/com/prgrms2/java/bitta/global/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/prgrms2/java/bitta/global/advice/GlobalControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.prgrms2.java.bitta.global.advice;
 
 import jakarta.validation.ConstraintViolationException;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -8,14 +9,21 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
+import java.util.List;
 import java.util.Map;
 
 @RestControllerAdvice
-public class GlovalExceptionHandler {
+public class GlobalControllerAdvice {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<?> handleArgsException(MethodArgumentNotValidException e) {
+        List<String> reasons = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .toList();
+
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("error", "잘못된 요청입니다.", "reason", e.getMessage()));
+                .body(Map.of("error", "잘못된 요청입니다.", "reason", reasons));
     }
 
     @ExceptionHandler(ConstraintViolationException.class)

--- a/src/main/java/com/prgrms2/java/bitta/security/SecurityConfig.java
+++ b/src/main/java/com/prgrms2/java/bitta/security/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/members/sign-in").permitAll()
                         .requestMatchers("/members/sign-up").permitAll()
-                        .requestMatchers("/members/test").hasRole("USER")
+                        .requestMatchers("/members/test", "/api/v1/feed**").hasRole("USER")
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/webjars/**").permitAll()
                         .requestMatchers("/images/**").permitAll()
                         .anyRequest().authenticated())

--- a/src/test/java/com/prgrms2/java/bitta/controller/FeedControllerTests.java
+++ b/src/test/java/com/prgrms2/java/bitta/controller/FeedControllerTests.java
@@ -6,7 +6,6 @@ import com.prgrms2.java.bitta.feed.controller.FeedController;
 import com.prgrms2.java.bitta.feed.dto.FeedDTO;
 import com.prgrms2.java.bitta.feed.exception.FeedException;
 import com.prgrms2.java.bitta.feed.service.FeedService;
-import com.prgrms2.java.bitta.token.util.JWTUtil;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,34 +13,35 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultMatcher;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WithMockUser
 @WebMvcTest(FeedController.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class FeedControllerTests {
     @MockBean
     private FeedService feedService;
-
-    @MockBean
-    private JWTUtil jwtUtil;
 
     @Autowired
     private MockMvc mockMvc;
@@ -59,8 +59,8 @@ public class FeedControllerTests {
                 .id(1L)
                 .title("Title")
                 .content("Content")
-                .createdAt(LocalDateTime.now())
-                .email("member@email.com")
+                .createdAt(LocalDateTime.of(2024, 10, 2, 0, 0))
+                .memberId(1L)
                 .build();
 
         feedDTOList = new ArrayList<>();
@@ -68,9 +68,23 @@ public class FeedControllerTests {
                 .id((long) i)
                 .title("Title" + i)
                 .content("Content" + i)
-                .createdAt(LocalDateTime.now())
-                .email("member@email.com")
+                .createdAt(LocalDateTime.of(2024, 10, 2, 0, 0))
+                .memberId((long) i)
                 .build()));
+    }
+
+    private MockMultipartFile generateMockMultipartFile(String name, String type, Object object) throws Exception {
+        MockMultipartFile mockMultipartFile;
+
+        if (type.equals(MediaType.APPLICATION_JSON_VALUE)) {
+            mockMultipartFile = new MockMultipartFile(name, "", MediaType.APPLICATION_JSON_VALUE
+                    , objectMapper.writeValueAsString(object).getBytes(StandardCharsets.UTF_8));
+        } else {
+            mockMultipartFile = new MockMultipartFile(name, "", MediaType.IMAGE_JPEG_VALUE
+                    , "Content".getBytes());
+        }
+
+        return mockMultipartFile;
     }
 
     private ResultMatcher[] generateResultMatchers(FeedDTO feedDTO) {
@@ -80,8 +94,8 @@ public class FeedControllerTests {
         resultMatchers.add(jsonPath(prefix + "id").value(feedDTO.getId()));
         resultMatchers.add(jsonPath(prefix + "title").value(feedDTO.getTitle()));
         resultMatchers.add(jsonPath(prefix + "content").value(feedDTO.getContent()));
-        resultMatchers.add(jsonPath(prefix + "email").value(feedDTO.getEmail()));
-        resultMatchers.add(jsonPath(prefix + "createdAt").value(feedDTO.getCreatedAt()));
+        resultMatchers.add(jsonPath(prefix + "memberId").value(feedDTO.getMemberId()));
+        resultMatchers.add(jsonPath(prefix + "createdAt").value("2024-10-02T00:00:00"));
 
         return resultMatchers.toArray(ResultMatcher[]::new);
     }
@@ -91,13 +105,13 @@ public class FeedControllerTests {
 
         for (int i = 0; i < feedDTOList.size(); i++) {
             FeedDTO feedDTO = feedDTOList.get(i);
-            String prefix = String.format("$result.[%d].", i);
+            String prefix = String.format("$.result.[%d].", i);
 
             resultMatchers.add(jsonPath(prefix + "id").value(feedDTO.getId()));
             resultMatchers.add(jsonPath(prefix + "title").value(feedDTO.getTitle()));
             resultMatchers.add(jsonPath(prefix + "content").value(feedDTO.getContent()));
-            resultMatchers.add(jsonPath(prefix + "email").value(feedDTO.getEmail()));
-            resultMatchers.add(jsonPath(prefix + "createdAt").value(feedDTO.getCreatedAt()));
+            resultMatchers.add(jsonPath(prefix + "memberId").value(feedDTO.getMemberId()));
+            resultMatchers.add(jsonPath(prefix + "createdAt").value("2024-10-02T00:00:00"));
         }
 
         return resultMatchers.toArray(ResultMatcher[]::new);
@@ -121,7 +135,7 @@ public class FeedControllerTests {
     @DisplayName("피드 전체 조회 (실패) :: 검색 결과 없음")
     void getFeed_FeedNotExists_NotFound() throws Exception {
         given(feedService.readAll())
-                .willReturn(new ArrayList<>());
+                .willThrow(FeedException.CANNOT_FOUND.get());
 
         mockMvc.perform(get("/api/v1/feed"))
                 .andDo(print())
@@ -160,15 +174,15 @@ public class FeedControllerTests {
     @Test
     @DisplayName("피드 등록 (성공)")
     void createFeed_FeedNotDuplicated_ReturnMessage() throws Exception {
-        doNothing().when(feedService).insert(any(FeedDTO.class));
+        doNothing().when(feedService).insert(any(FeedDTO.class), any());
 
-        String content = objectMapper.writeValueAsString(feedDTO);
-
-        mockMvc.perform(post("/api/v1/feed")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(content))
+        mockMvc.perform(multipart(HttpMethod.POST, "/api/v1/feed")
+                        .file(generateMockMultipartFile("file", MediaType.IMAGE_JPEG_VALUE, null))
+                        .file(generateMockMultipartFile("feed", MediaType.APPLICATION_JSON_VALUE, feedDTO))
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .with(csrf()))
                 .andDo(print())
-                .andExpect(status().isCreated())
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message")
                         .value("피드가 등록되었습니다."));
     }
@@ -177,13 +191,13 @@ public class FeedControllerTests {
     @DisplayName("피드 등록 (실패) :: ID 값이 존재함")
     void createFeed_IdExistsInDto_HttpStatusBadRequest() throws Exception {
         doThrow(FeedException.BAD_REQUEST.get())
-                .when(feedService).insert(any(FeedDTO.class));
+                .when(feedService).insert(any(FeedDTO.class), any());
 
-        String content = objectMapper.writeValueAsString(FeedDTO.builder().build());
-
-        mockMvc.perform(post("/api/v1/feed")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(content))
+        mockMvc.perform(multipart(HttpMethod.POST, "/api/v1/feed")
+                        .file(generateMockMultipartFile("file", MediaType.IMAGE_JPEG_VALUE, null))
+                        .file(generateMockMultipartFile("feed", MediaType.APPLICATION_JSON_VALUE, feedDTO))
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error")
@@ -191,33 +205,16 @@ public class FeedControllerTests {
     }
 
     @Test
-    @DisplayName("피드 등록 (실패) :: DTO 검증 실패")
-    void createFeed_WrongRequestDto_ThrowMethodArgumentNotValidException() throws Exception {
-        FeedDTO emptyDto = FeedDTO.builder().build();
-
-        String content = objectMapper.writeValueAsString(emptyDto);
-
-        mockMvc.perform(put("/api/v1/feed")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(content))
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error")
-                        .value("잘못된 요청입니다."))
-                .andExpect(jsonPath("$.reason")
-                        .value("제목은 비워둘 수 없습니다."));
-    }
-
-    @Test
     @DisplayName("피드 수정 (성공)")
     void modifyFeed_FeedDtoIsNotEmpty_ReturnFeedDto() throws Exception {
-        doNothing().when(feedService).update(any(FeedDTO.class), photos, videos);
+        doNothing().when(feedService).update(any(FeedDTO.class), any(), any());
 
-        String content = objectMapper.writeValueAsString(feedDTO);
-
-        mockMvc.perform(put("/api/v1/feed/1")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(content))
+        mockMvc.perform(multipart(HttpMethod.PUT, "/api/v1/feed/1")
+                        .file(generateMockMultipartFile("filesToUpload", MediaType.IMAGE_JPEG_VALUE, null))
+                        .file(generateMockMultipartFile("feed", MediaType.APPLICATION_JSON_VALUE, feedDTO))
+                        .file(generateMockMultipartFile("filepathsToDelete", MediaType.APPLICATION_JSON_VALUE, new ArrayList<>()))
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message")
@@ -228,13 +225,14 @@ public class FeedControllerTests {
     @DisplayName("피드 수정 (실패) :: 검색 결과 없음")
     void modifyFeed_FeedDtoIsNotEmpty_HttpStatusBadRequest() throws Exception {
         doThrow(FeedException.CANNOT_FOUND.get())
-                .when(feedService).update(any(FeedDTO.class), photos, videos);
+                .when(feedService).update(any(FeedDTO.class), any(), any());
 
-        String content = objectMapper.writeValueAsString(feedDTO);
-
-        mockMvc.perform(put("/api/v1/feed/1")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(content))
+        mockMvc.perform(multipart(HttpMethod.PUT, "/api/v1/feed/1")
+                        .file(generateMockMultipartFile("filesToUpload", MediaType.IMAGE_JPEG_VALUE, null))
+                        .file(generateMockMultipartFile("feed", MediaType.APPLICATION_JSON_VALUE, feedDTO))
+                        .file(generateMockMultipartFile("filepathsToDelete", MediaType.APPLICATION_JSON_VALUE, new ArrayList<>()))
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error")
@@ -246,17 +244,16 @@ public class FeedControllerTests {
     void modifyFeed_WrongRequestDto_ThrowMethodArgumentNotValidException() throws Exception {
         FeedDTO emptyDto = FeedDTO.builder().build();
 
-        String content = objectMapper.writeValueAsString(emptyDto);
-
-        mockMvc.perform(put("/api/v1/feed/1")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(content))
+        mockMvc.perform(multipart(HttpMethod.PUT, "/api/v1/feed/1")
+                        .file(generateMockMultipartFile("filesToUpload", MediaType.IMAGE_JPEG_VALUE, null))
+                        .file(generateMockMultipartFile("feed", MediaType.APPLICATION_JSON_VALUE, new FeedDTO()))
+                        .file(generateMockMultipartFile("filepathsToDelete", MediaType.APPLICATION_JSON_VALUE, new ArrayList<>()))
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error")
-                        .value("잘못된 요청입니다."))
-                .andExpect(jsonPath("$.reason")
-                        .value("제목은 비워둘 수 없습니다."));
+                        .value("잘못된 요청입니다."));
     }
 
     @Test
@@ -264,7 +261,8 @@ public class FeedControllerTests {
     void deleteFeed_FeedExists_HttpStatusNoContent() throws Exception {
         doNothing().when(feedService).delete(anyLong());
 
-        mockMvc.perform(delete("/api/v1/feed/1"))
+        mockMvc.perform(delete("/api/v1/feed/1")
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message")
@@ -277,7 +275,8 @@ public class FeedControllerTests {
         doThrow(FeedException.CANNOT_DELETE.get())
                 .when(feedService).delete(anyLong());
 
-        mockMvc.perform(delete("/api/v1/feed/1"))
+        mockMvc.perform(delete("/api/v1/feed/1")
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error")
@@ -287,7 +286,8 @@ public class FeedControllerTests {
     @Test
     @DisplayName("피드 삭제 (실패) :: 잘못된 경로 변수")
     void deleteFeed_WrongPathVariable_ThrowConstraintViolationException() throws Exception {
-        mockMvc.perform(delete("/api/v1/feed/-1"))
+        mockMvc.perform(delete("/api/v1/feed/-1")
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error")


### PR DESCRIPTION
## #️⃣연관된 이슈
Related to: #21


## ☑️ PR 유형
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 테스트 추가, 테스트 리팩토링
- [x] 파일 혹은 폴더명 수정


## 📝 작업 내용
#### 피드 컨트롤러 테스트 오류 수정
- DTO의 회원 ID에 적용된 `@NotBlank` 어노테이션을 `@NotNull`로 변경합니다.
- GlovalExceptionHandler를 GlobalControllerAdvice로 변경합니다.
- MethodArgumentNotValidException 에러 메시지를 리스트로 반환하도록 설정합니다.
- SecurityConfig에 피드 관련 API에 USER가 접근할 수 있도록 설정합니다.
- 피드 컨트롤러 테스트 코드 전반을 수정합니다.

Commit: a565a5e286e3b579d0b6d72855c22e693e6fd512

## ✅ 피드백 반영사항
작업 중에 특별한 오류는 없었습니다.

## 💬 리뷰 요구사항
파일이 변경된 부분이 존재하여 각 브랜치의 최신화가 필요합니다.