### PR TITLE
pullrequest: 피드 서비스 테스트 코드 추가

### DIFF
--- a/src/main/java/com/prgrms2/java/bitta/BittaApplication.java
+++ b/src/main/java/com/prgrms2/java/bitta/BittaApplication.java
@@ -4,11 +4,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class
-BittaApplication {
-
+public class BittaApplication {
     public static void main(String[] args) {
         SpringApplication.run(BittaApplication.class, args);
     }
-
 }

--- a/src/main/java/com/prgrms2/java/bitta/feed/service/FeedServiceImpl.java
+++ b/src/main/java/com/prgrms2/java/bitta/feed/service/FeedServiceImpl.java
@@ -97,11 +97,8 @@ public class FeedServiceImpl implements FeedService {
     @Override
     @Transactional
     public void delete(Long id) {
-
-        Feed feed = feedRepository.findById(id).orElseThrow(FeedException.CANNOT_FOUND::get);
-
-        photoService.deletePhotosByFeed(feed);
-        videoService.deleteVideosByFeed(feed);
+        photoService.delete(id);
+        videoService.delete(id);
 
         if (feedRepository.deleteByIdAndReturnCount(id) == 0) {
             throw FeedException.CANNOT_DELETE.get();
@@ -154,7 +151,7 @@ public class FeedServiceImpl implements FeedService {
                 .title(feed.getTitle())
                 .content(feed.getContent())
                 .createdAt(feed.getCreatedAt())
-                .id(feed.getMember().getId())
+                .memberId(feed.getMember().getId())
                 .photoUrls(feed.getPhotos().stream()
                         .map(Photo::getPhotoUrl).toList())
                 .videoUrls(feed.getVideos().stream()

--- a/src/main/java/com/prgrms2/java/bitta/photo/repository/PhotoRepository.java
+++ b/src/main/java/com/prgrms2/java/bitta/photo/repository/PhotoRepository.java
@@ -1,15 +1,17 @@
 package com.prgrms2.java.bitta.photo.repository;
 
-import com.prgrms2.java.bitta.feed.entity.Feed;
 import com.prgrms2.java.bitta.photo.entity.Photo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
-    List<Photo> findByFeed(Feed feed);
+    @Query("SELECT p.photoUrl FROM Photo p WHERE p.feed.id = :feedId")
+    List<String> findPhotoUrlByFeedId(@Param("feedId") Long feedId);
 
     void deleteByPhotoUrl(String photoUrl);
 }

--- a/src/main/java/com/prgrms2/java/bitta/photo/service/PhotoService.java
+++ b/src/main/java/com/prgrms2/java/bitta/photo/service/PhotoService.java
@@ -1,18 +1,14 @@
 package com.prgrms2.java.bitta.photo.service;
 
-import com.prgrms2.java.bitta.feed.entity.Feed;
 import com.prgrms2.java.bitta.photo.entity.Photo;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.List;
 
 public interface PhotoService {
     Photo upload(MultipartFile file) throws IOException;
 
     void delete(String filepath);
 
-    List<Photo> uploadPhotos(List<MultipartFile> files, Feed feed) throws IOException;
-
-    void deletePhotosByFeed(Feed feed);
+    void delete(Long feedId);
 }

--- a/src/main/java/com/prgrms2/java/bitta/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/prgrms2/java/bitta/photo/service/PhotoServiceImpl.java
@@ -1,6 +1,5 @@
 package com.prgrms2.java.bitta.photo.service;
 
-import com.prgrms2.java.bitta.feed.entity.Feed;
 import com.prgrms2.java.bitta.photo.entity.Photo;
 import com.prgrms2.java.bitta.photo.repository.PhotoRepository;
 import lombok.RequiredArgsConstructor;
@@ -49,42 +48,16 @@ public class PhotoServiceImpl implements PhotoService{
         }
     }
 
-    @Transactional
-    public List<Photo> uploadPhotos(List<MultipartFile> files, Feed feed) throws IOException {
+    @Override
+    public void delete(Long feedId) {
+        List<String> photoUrls = photoRepository.findPhotoUrlByFeedId(feedId);
 
-        List<Photo> existingPhotos = photoRepository.findByFeed(feed);
+        photoUrls.forEach(url -> {
+            File file = new File(url);
 
-        if (existingPhotos.size() + files.size() > 4) {
-            throw new IllegalArgumentException("사진은 4만 업로드 할 수 있습니다");
-        }
-
-        for (MultipartFile file : files) {
-
-            if (file.getSize() > 10 * 1024 * 1024) {
-                throw new IllegalArgumentException("사진의 크기는 10mb 를 넘을 수 없습니다");
+            if (file.exists()) {
+                file.delete();
             }
-
-            String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
-            String filePath = "uploads/photos/" + fileName;
-
-            File dest = new File(filePath);
-            file.transferTo(dest);
-
-            Photo photo = Photo.builder()
-                    .photoUrl(filePath)
-                    .fileSize(file.getSize())
-                    .feed(feed)
-                    .build();
-
-            photoRepository.save(photo);
-        }
-        return photoRepository.findByFeed(feed);
-    }
-
-    @Transactional
-    public void deletePhotosByFeed(Feed feed) {
-        List<Photo> photos = photoRepository.findByFeed(feed);
-
-        photoRepository.deleteAll(photos);
+        });
     }
 }

--- a/src/main/java/com/prgrms2/java/bitta/video/repository/VideoRepository.java
+++ b/src/main/java/com/prgrms2/java/bitta/video/repository/VideoRepository.java
@@ -1,15 +1,17 @@
 package com.prgrms2.java.bitta.video.repository;
 
-import com.prgrms2.java.bitta.feed.entity.Feed;
 import com.prgrms2.java.bitta.video.entity.Video;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface VideoRepository extends JpaRepository<Video, Long> {
-    List<Video> findByFeed(Feed feed);
+    @Query("SELECT v.videoUrl FROM Video v WHERE v.feed.id = :feedId")
+    List<String> findVideoUrlByFeedId(@Param("feedId") Long feedId);
 
     void deleteByVideoUrl(String videoUrl);
 }

--- a/src/main/java/com/prgrms2/java/bitta/video/service/VideoService.java
+++ b/src/main/java/com/prgrms2/java/bitta/video/service/VideoService.java
@@ -1,19 +1,15 @@
 package com.prgrms2.java.bitta.video.service;
 
-import com.prgrms2.java.bitta.feed.entity.Feed;
 import com.prgrms2.java.bitta.video.entity.Video;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.List;
 
 public interface VideoService {
     Video upload(MultipartFile file) throws IOException;
 
     void delete(String filepath);
 
-    List<Video> uploadVideos(List<MultipartFile> files, Feed feed) throws IOException;
-
-    void deleteVideosByFeed(Feed feed);
+    void delete(Long feedId);
 }
 

--- a/src/main/java/com/prgrms2/java/bitta/video/service/VideoServiceImpl.java
+++ b/src/main/java/com/prgrms2/java/bitta/video/service/VideoServiceImpl.java
@@ -1,6 +1,5 @@
 package com.prgrms2.java.bitta.video.service;
 
-import com.prgrms2.java.bitta.feed.entity.Feed;
 import com.prgrms2.java.bitta.video.entity.Video;
 import com.prgrms2.java.bitta.video.repository.VideoRepository;
 import lombok.RequiredArgsConstructor;
@@ -49,37 +48,16 @@ public class VideoServiceImpl implements VideoService {
         }
     }
 
-    @Transactional
-    public List<Video> uploadVideos(List<MultipartFile> files, Feed feed) throws IOException {
+    @Override
+    public void delete(Long feedId) {
+        List<String> videoUrls = videoRepository.findVideoUrlByFeedId(feedId);
 
-        List<Video> existingVideos = videoRepository.findByFeed(feed);
+        videoUrls.forEach(url -> {
+            File file = new File(url);
 
-        if (existingVideos.size() + files.size() > 1) {
-            throw new IllegalArgumentException("비디오는 한개만 업로드 할 수 있습니다");
-        }
-
-        for (MultipartFile file : files) {
-
-            String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
-            String filePath = "uploads/videos/" + fileName;
-
-            File dest = new File(filePath);
-            file.transferTo(dest);
-
-            Video video = Video.builder()
-                    .videoUrl(filePath)
-                    .fileSize(file.getSize())
-                    .feed(feed)
-                    .build();
-
-            videoRepository.save(video);
-        }
-        return videoRepository.findByFeed(feed);
-    }
-
-    @Transactional
-    public void deleteVideosByFeed(Feed feed) {
-        List<Video> videos = videoRepository.findByFeed(feed);
-        videoRepository.deleteAll(videos);
+            if (file.exists()) {
+                file.delete();
+            }
+        });
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,5 @@ spring.application.name=bitta
 file.root.path = C:\\
 
 # File size restriction
-spring.servlet.multipart.max-file-size=500MB
-spring.servlet.multipart.max-request-size=1GB
-server.tomcat.max-http-form-post-size=1GB
-
+spring.servlet.multipart.max-file-size=25MB
+spring.servlet.multipart.max-request-size=50MB

--- a/src/test/java/com/prgrms2/java/bitta/service/FeedServiceTests.java
+++ b/src/test/java/com/prgrms2/java/bitta/service/FeedServiceTests.java
@@ -1,0 +1,308 @@
+package com.prgrms2.java.bitta.service;
+
+import com.prgrms2.java.bitta.feed.dto.FeedDTO;
+import com.prgrms2.java.bitta.feed.entity.Feed;
+import com.prgrms2.java.bitta.feed.exception.FeedException;
+import com.prgrms2.java.bitta.feed.exception.FeedTaskException;
+import com.prgrms2.java.bitta.feed.repository.FeedRepository;
+import com.prgrms2.java.bitta.feed.service.FeedServiceImpl;
+import com.prgrms2.java.bitta.member.dto.MemberProvider;
+import com.prgrms2.java.bitta.member.entity.Member;
+import com.prgrms2.java.bitta.photo.entity.Photo;
+import com.prgrms2.java.bitta.photo.service.PhotoService;
+import com.prgrms2.java.bitta.video.service.VideoService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+public class FeedServiceTests {
+    @InjectMocks
+    private FeedServiceImpl feedServiceImpl;
+
+    @Mock
+    private FeedRepository feedRepository;
+
+    @Mock
+    private MemberProvider memberProvider;
+
+    @Mock
+    private PhotoService photoService;
+
+    @Mock
+    private VideoService videoService;
+
+    private Member member;
+
+    private Feed feed;
+
+    private FeedDTO feedDTO;
+
+    private Photo photo;
+
+    private List<Feed> feeds;
+
+    private List<MultipartFile> files;
+
+    @BeforeEach
+    void initialize() {
+        member = Member.builder()
+                .id(1L)
+                .username("Username")
+                .password("Password")
+                .address("Address")
+                .profileImg("ImageUrl")
+                .build();
+
+        feed = Feed.builder()
+                .id(1L)
+                .title("Title")
+                .content("Content")
+                .member(member)
+                .build();
+
+        feedDTO = FeedDTO.builder()
+                .id(1L)
+                .title("Title")
+                .content("Content")
+                .memberId(1L)
+                .build();
+
+        photo = Photo.builder()
+                .photoId(1L)
+                .photoUrl("uploads/photos/fake")
+                .fileSize(100000L)
+                .feed(feed)
+                .build();
+
+        feeds = new ArrayList<>();
+        IntStream.rangeClosed(1, 5).forEach(i -> {
+            Feed _feed = Feed.builder()
+                    .id((long) i)
+                    .title("Title" + i)
+                    .content("Content" + i)
+                    .member(member)
+                    .build();
+
+            feeds.add(_feed);
+        });
+
+        files = new ArrayList<>();
+        MultipartFile file = new MockMultipartFile("image", "image.png"
+                , MediaType.IMAGE_PNG_VALUE, "image".getBytes());
+        files.add(file);
+    }
+
+    void assertObject(FeedDTO feedDTO) {
+        assertThat(feedDTO.getId()).isEqualTo(1L);
+        assertThat(feedDTO.getTitle()).isEqualTo("Title");
+        assertThat(feedDTO.getContent()).isEqualTo("Content");
+        assertThat(feedDTO.getMemberId()).isEqualTo(1L);
+    }
+
+    void assertObject(List<FeedDTO> feedDTOs) {
+        for (int i = 1; i < feedDTOs.size() + 1; i++) {
+            FeedDTO _feedDTO = feedDTOs.get(i - 1);
+            assertThat(_feedDTO.getId()).isEqualTo(i);
+            assertThat(_feedDTO.getTitle()).isEqualTo("Title" + i);
+            assertThat(_feedDTO.getContent()).isEqualTo("Content" + i);
+            assertThat(_feedDTO.getMemberId()).isEqualTo(1L);
+        }
+    }
+
+    @Test
+    @DisplayName("피드 단일 조회 (성공)")
+    void read_ValidId_ReturnFeedDTO() {
+        when(feedRepository.findById(anyLong()))
+                .thenReturn(Optional.of(feed));
+
+        FeedDTO feedDTO = feedServiceImpl.read(1L);
+
+        assertObject(feedDTO);
+    }
+
+    @Test
+    @DisplayName("피드 단일 조회 (실패) :: 일치하는 피드 없음")
+    void read_InvalidId_ThrowException() {
+        feedDTO.setId(null);
+
+        when(feedRepository.findById(anyLong()))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> feedServiceImpl.read(1L))
+                .isInstanceOf(FeedTaskException.class)
+                .hasMessage("피드가 존재하지 않습니다.");
+    }
+    
+    @Test
+    @DisplayName("피드 전체 조회 (성공)")
+    void readAll_FeedExists_ReturnDtoList() {
+        when(feedRepository.findAll())
+                .thenReturn(feeds);
+
+        List<FeedDTO> feedDTOs = feedServiceImpl.readAll();
+
+        assertObject(feedDTOs);
+    }
+
+    @Test
+    @DisplayName("피드 전체 조회 (실패) :: 피드 없음")
+    void readAll_FeedNotExists_ThrowException() {
+        when(feedRepository.findAll())
+                .thenReturn(new ArrayList<>());
+
+        assertThatThrownBy(() -> feedServiceImpl.readAll())
+                .isInstanceOf(FeedTaskException.class)
+                .hasMessage("피드가 존재하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("피드 삽입 (성공)")
+    void insert_ProcessWithoutException_InsertSuccess() throws Exception {
+        feedDTO.setId(null);
+
+        when(photoService.upload(any(MultipartFile.class)))
+                .thenReturn(photo);
+
+        when(feedRepository.save(any(Feed.class)))
+                .thenReturn(feed);
+
+        when(memberProvider.getById(anyLong())).thenReturn(member);
+
+        feedServiceImpl.insert(feedDTO, files);
+    }
+
+    @Test
+    @DisplayName("피드 삽입 (실패) :: 업데이트를 시도함")
+    void insert_DtoContainsId_ThrowException() {
+        assertThatThrownBy(() -> feedServiceImpl.insert(feedDTO, files))
+                .isInstanceOf(FeedTaskException.class)
+                .hasMessage("잘못된 요청입니다.");
+    }
+
+    @Test
+    @DisplayName("피드 삽입 (실패) :: 파일 저장 실패")
+    void insert_SaveWrongFile_ThrowException() throws IOException {
+        feedDTO.setId(null);
+
+        when(photoService.upload(any(MultipartFile.class)))
+                .thenThrow(new IOException());
+
+        assertThatThrownBy(() -> feedServiceImpl.insert(feedDTO, files))
+                .isInstanceOf(FeedTaskException.class)
+                .hasMessage("서버 내부에 오류가 발생했습니다.");
+    }
+
+    @Test
+    @DisplayName("피드 수정 (성공)")
+    void update_ProcessWithoutException_UpdateSuccess() throws IOException {
+        when(feedRepository.findById(anyLong()))
+                .thenReturn(Optional.of(feed));
+
+        doNothing().when(photoService).delete(anyString());
+
+        when(photoService.upload(any(MultipartFile.class)))
+                .thenReturn(photo);
+
+        when(feedRepository.save(any(Feed.class)))
+                .thenReturn(feed);
+
+        feedServiceImpl.update(feedDTO, files, new ArrayList<String>(){{
+            add("uploads/photos/fake1");
+            add("uploads/photos/fake2");
+        }});
+    }
+
+    @Test
+    @DisplayName("피드 수정 (실패) :: 피드 검색 실패")
+    void update_FeedNotExists_ThrowException() {
+        when(feedRepository.findById(anyLong()))
+                .thenThrow(FeedException.CANNOT_FOUND.get());
+
+        assertThatThrownBy(() -> feedServiceImpl.update(feedDTO, files, new ArrayList<String>()))
+                .isInstanceOf(FeedTaskException.class)
+                .hasMessage("피드가 존재하지 않습니다.");
+    }
+    
+    @Test
+    @DisplayName("피드 수정 (실패) :: 파일 삭제 실패")
+    void update_FileDeleteFailed_ThrowException() {
+        when(feedRepository.findById(anyLong()))
+                .thenReturn(Optional.of(feed));
+
+        doThrow(NoSuchElementException.class)
+                .when(photoService).delete(anyString());
+
+        assertThatThrownBy(() -> feedServiceImpl.update(feedDTO, files, new ArrayList<String>(){{
+            add("uploads/photos/fake1");
+            add("uploads/photos/fake2");}}))
+                .isInstanceOf(FeedTaskException.class)
+                .hasMessage("서버 내부에 오류가 발생했습니다.");
+    }
+
+    @Test
+    @DisplayName("피드 수정 (실패) :: 파일 저장 실패")
+    void update_FileSaveFailed_ThrowException() throws IOException {
+        when(feedRepository.findById(anyLong()))
+                .thenReturn(Optional.of(feed));
+
+        doNothing().when(photoService).delete(anyString());
+
+        when(photoService.upload(any(MultipartFile.class)))
+                .thenThrow(FeedException.INTERNAL_ERROR.get());
+
+        assertThatThrownBy(() -> feedServiceImpl.update(feedDTO, files, new ArrayList<String>(){{
+            add("uploads/photos/fake1");
+            add("uploads/photos/fake2");}}))
+                .isInstanceOf(FeedTaskException.class)
+                .hasMessage("서버 내부에 오류가 발생했습니다.");
+    }
+
+    @Test
+    @DisplayName("피드 삭제 (성공)")
+    void delete_ProcessWithoutException_DeleteSuccess() {
+        doNothing().when(photoService).delete(anyLong());
+        doNothing().when(videoService).delete(anyLong());
+
+        when(feedRepository.deleteByIdAndReturnCount(anyLong()))
+                .thenReturn(1L);
+
+        feedServiceImpl.delete(1L);
+
+        verify(photoService, times(1)).delete(anyLong());
+        verify(videoService, times(1)).delete(anyLong());
+    }
+
+    @Test
+    @DisplayName("피드 삭제 (실패) :: 피드 검색 실패")
+    void delete_FeedNotExists_ThrowException() {
+        doNothing().when(photoService).delete(anyLong());
+        doNothing().when(videoService).delete(anyLong());
+
+        when(feedRepository.deleteByIdAndReturnCount(anyLong()))
+                .thenReturn(0L);
+
+        assertThatThrownBy(() -> feedServiceImpl.delete(1L))
+                .isInstanceOf(FeedTaskException.class)
+                .hasMessage("삭제할 피드가 존재하지 않습니다");
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
Related to: #71 


## ☑️ PR 유형
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정


## 📝 작업 내용
#### 잘못된 줄바꿈 수정
BittaApplication에 잘못 들어간 줄바꿈을 수정합니다.

Commit: 255cfa63b0091d7946249d1b30cbf26134b7e8d2

#### 파일 관련 컴포넌트 수정
- 피드 ID로 파일의 URL을 조회하는 쿼리 메소드를 추가합니다.
- 피드 삭제 메소드 작동 순서를 설정합니다. (파일 제거 -> 레코드 제거)
- 엔티티 -> DTO 변환 메소드 잘못된 FK 필드 참조 수정합니다.
- 불필요한 파일 서비스 메소드 제거합니다.

Commit: 6fb87a008be1bd28d1b637b2385663f4757efed6

#### 피드 서비스 테스트 코드 추가
FeedService의 전체 메소드의 성공 실패 테스트 코드 작성합니다.

Commit: f6a46163397d97a5819303a670ff62cd15d69475

#### 파일 업로드 크기 제한
500MB, 1GB로 설정되어있는 파일 제한을 25MB, 50MB로 대폭 낮춥니다.
배포 환경 구축 중에 재설정이 필요할 수 있습니다.

Commit: 185dcff17f44dbfb2845b418d3a9162ac482c1f2


## ✅ 피드백 반영사항
파일 업로드 크기를 임의로 제한했습니다.


## 💬 리뷰 요구사항
변경된 파일이 많기 때문에, 각 브랜치의 최신화가 필요합니다.
